### PR TITLE
Replace vector tiles library

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -12,6 +12,9 @@ RUN mkdir -p /app
 WORKDIR /app
 
 COPY requirements.txt requirements-dev.txt .
-RUN pip install -r requirements.txt -r requirements-dev.txt
+
+RUN apk add geos geos-dev alpine-sdk && \
+    pip install -r requirements.txt -r requirements-dev.txt && \
+    apk del alpine-sdk geos-dev
 
 EXPOSE 5000

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,7 +4,7 @@ RUN apk update && \
     apk upgrade && \
     apk add bash
 
-# set environment variables
+# Set environment variables
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,4 +1,32 @@
-FROM python:3.11-alpine
+# builder stage for compiling dependencies
+FROM python:3.11-alpine AS builder
+
+# install geos-dev and alpine-sdk (which contains the compilers needed for building wheels)
+RUN apk update && \
+    apk upgrade && \
+    apk add geos-dev alpine-sdk
+
+# set environment variables
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+# create venv
+RUN python -m venv /opt/venv
+# make sure to use the venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# install dependencies to venv
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+
+# actual application runtime stage (without build dependencies)
+FROM python:3.11-alpine AS runtime
+
+# install geos at system level (needed as a sub-dependency of mapbox-vector-tile)
+RUN apk update && \
+    apk upgrade && \
+    apk add geos
 
 # set environment variables
 ENV PYTHONDONTWRITEBYTECODE 1
@@ -6,9 +34,13 @@ ENV PYTHONUNBUFFERED 1
 
 WORKDIR /app
 
-COPY requirements.txt .
-RUN pip install -r requirements.txt
+# copy venv with installed dependencies from the builder stage
+COPY --from=builder /opt/venv /opt/venv
 
+# make sure to use the venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# copy application code
 COPY . /app
 
 EXPOSE 5000

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,46 +1,46 @@
-# builder stage for compiling dependencies
+# Builder stage for compiling dependencies
 FROM python:3.11-alpine AS builder
 
-# install geos-dev and alpine-sdk (which contains the compilers needed for building wheels)
+# Install geos-dev and alpine-sdk (which contains the compilers needed for building wheels)
 RUN apk update && \
     apk upgrade && \
     apk add geos-dev alpine-sdk
 
-# set environment variables
+# Set environment variables
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
-# create venv
+# Create venv
 RUN python -m venv /opt/venv
-# make sure to use the venv
+# Make sure to use the venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-# install dependencies to venv
+# Install dependencies to venv
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 
 
-# actual application runtime stage (without build dependencies)
+# Actual application runtime stage (without build dependencies)
 FROM python:3.11-alpine AS runtime
 
-# install geos at system level (needed as a sub-dependency of mapbox-vector-tile)
+# Install geos at system level (needed as a sub-dependency of mapbox-vector-tile)
 RUN apk update && \
     apk upgrade && \
     apk add geos
 
-# set environment variables
+# Set environment variables
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
 WORKDIR /app
 
-# copy venv with installed dependencies from the builder stage
+# Copy venv with installed dependencies from the builder stage
 COPY --from=builder /opt/venv /opt/venv
 
-# make sure to use the venv
+# Make sure to use the venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-# copy application code
+# Copy application code
 COPY . /app
 
 EXPOSE 5000

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,14 +3,12 @@
 ## System requirements
 
 This application is a flask application with following requirements:
-* Python 3.7+
-* SQLAlchemy-compatible SQL-server (eg MariaDB)
+* Python 3.11+
+* SQLAlchemy-compatible SQL-server (e.g. MariaDB)
 * An AMQP-Queue (eg RabbitMQ)
 
 
-## Production version
-
-
+## Production version (legacy)
 
 1) Use `virtualenv -p python3 venv` to create a virtual environment
 2) Use `./venv/bin/pip install -r requirements.txt` to install required packages
@@ -20,7 +18,14 @@ This application is a flask application with following requirements:
 6) Use `./venv/bin/flask` to start downloads
 
 
-## Development version via docker
+## Production setup (via Docker)
+
+This is the recommended way of installation now.
+
+*TODO: add instructions here*
+
+
+## Development setup (via Docker)
 
 1) Use `make first-start` to create a dev environment
 2) Use `make` to start the container

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,14 +20,13 @@ pyyaml~=6.0.1
 validataclass~=0.10.0
 SQLAlchemy-Utc~=0.14.0
 openpyxl~=3.1.5
-protobuf~=3.20.2
 pycountry~=23.12.11
 ngram~=4.0.3
 geopy~=2.4.1
 celery~=5.4.0
 kombu~=5.3.7
 pytz~=2024.1
-https://github.com/mapbox/vector-tile-base/archive/refs/heads/master.tar.gz
+mapbox-vector-tile~=2.1.0
 
 # binary butterfly shared libraries (https://git.binary-butterfly.de/public_libraries)
 --extra-index-url https://git.binary-butterfly.de/api/v4/groups/262/-/packages/pypi/simple

--- a/webapp/common/__init__.py
+++ b/webapp/common/__init__.py
@@ -15,3 +15,5 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
+
+from .logger import Logger

--- a/webapp/public_api/tiles_api/tiles_handler.py
+++ b/webapp/public_api/tiles_api/tiles_handler.py
@@ -17,12 +17,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 import mercantile
-from vector_tile_base import VectorTile
+from mapbox_vector_tile import encode
 
 from webapp.public_api.base_handler import PublicApiBaseHandler
 from webapp.public_api.tiles_api.tiles_validators import TileFilterInput
 from webapp.repositories import LocationRepository
 
+RENDER_CHARGEPOINTS_MIN_ZOOM = 8
 
 class TilesHandler(PublicApiBaseHandler):
     location_repository: LocationRepository
@@ -32,35 +33,40 @@ class TilesHandler(PublicApiBaseHandler):
         self.location_repository = location_respository
 
     def generate_tile(self, x: int, y: int, z: int, tile_filter_input: TileFilterInput) -> bytes:
-        tile = VectorTile()
-        if z < 8:
-            tile.serialize()
+        # don't render any chargepoints if zoomed out too far
+        if z < RENDER_CHARGEPOINTS_MIN_ZOOM:
+            return encode(layers=[])
 
-        bbox = mercantile.bounds(x, y, z)
+        # fetch chargepoints in the tile's bounding box
+        bbox = mercantile.bounds((x, y, z))
         chargepoints = self.location_repository.fetch_locations_summary_by_bounds(
             bbox,
             filter_duplicates=tile_filter_input.filter_duplicates,
             static=tile_filter_input.static,
         )
 
-        layer = tile.add_layer('chargepoints', 1)
+        # create layer dict
+        layer = {
+            'name': 'chargepoints',
+            'features': [],
+        }
+
+        # add features for chargepoints
         for item in chargepoints:
-            feature = layer.add_point_feature()
-            feature.add_points(
-                [
-                    int(4096 * (float(item.lon) - bbox[0]) / (bbox[2] - bbox[0])),
-                    int(4096 * (bbox[3] - float(item.lat)) / (bbox[3] - bbox[1])),
-                ]
-            )
-            feature.id = item.id
-            feature.attributes = {
-                'id': item.id,
-                'name': item.name or item.address,
-                'c': item.chargepoint_count,
-                'ca': int(item.chargepoint_available_count),
-                'cu': int(item.chargepoint_unknown_count),
-                'cb': int(item.chargepoint_bike_count),
-                'cs': int(item.chargepoint_static_count),
+            point_x = int(4096 * (float(item.lon) - bbox[0]) / (bbox[2] - bbox[0]))
+            point_y = int(4096 * (bbox[3] - float(item.lat)) / (bbox[3] - bbox[1]))
+            feature = {
+                'geometry': f'POINT({point_x}, {point_y})',
+                'properties': {
+                    'id': item.id,
+                    'name': item.name or item.address,
+                    'c': item.chargepoint_count,
+                    'ca': int(item.chargepoint_available_count),
+                    'cu': int(item.chargepoint_unknown_count),
+                    'cb': int(item.chargepoint_bike_count),
+                    'cs': int(item.chargepoint_static_count),
+                },
             }
-            feature.extend = 4096
-        return tile.serialize()
+            layer['features'].append(feature)
+
+        return encode(layers=[layer])

--- a/webapp/public_api/tiles_api/tiles_handler.py
+++ b/webapp/public_api/tiles_api/tiles_handler.py
@@ -69,4 +69,4 @@ class TilesHandler(PublicApiBaseHandler):
             }
             layer['features'].append(feature)
 
-        return encode(layers=[layer])
+        return encode(layers=[layer], default_options={'y_coord_down': True})

--- a/webapp/public_api/tiles_api/tiles_handler.py
+++ b/webapp/public_api/tiles_api/tiles_handler.py
@@ -33,11 +33,11 @@ class TilesHandler(PublicApiBaseHandler):
         self.location_repository = location_respository
 
     def generate_tile(self, x: int, y: int, z: int, tile_filter_input: TileFilterInput) -> bytes:
-        # don't render any chargepoints if zoomed out too far
+        # Don't render any chargepoints if zoomed out too far
         if z < RENDER_CHARGEPOINTS_MIN_ZOOM:
             return encode(layers=[])
 
-        # fetch chargepoints in the tile's bounding box
+        # Fetch chargepoints in the tile's bounding box
         bbox = mercantile.bounds((x, y, z))
         chargepoints = self.location_repository.fetch_locations_summary_by_bounds(
             bbox,
@@ -45,13 +45,13 @@ class TilesHandler(PublicApiBaseHandler):
             static=tile_filter_input.static,
         )
 
-        # create layer dict
+        # Create layer dict
         layer = {
             'name': 'chargepoints',
             'features': [],
         }
 
-        # add features for chargepoints
+        # Add features for chargepoints
         for item in chargepoints:
             point_x = int(4096 * (float(item.lon) - bbox[0]) / (bbox[2] - bbox[0]))
             point_y = int(4096 * (bbox[3] - float(item.lat)) / (bbox[3] - bbox[1]))

--- a/webapp/public_api/tiles_api/tiles_handler.py
+++ b/webapp/public_api/tiles_api/tiles_handler.py
@@ -56,7 +56,7 @@ class TilesHandler(PublicApiBaseHandler):
             point_x = int(4096 * (float(item.lon) - bbox[0]) / (bbox[2] - bbox[0]))
             point_y = int(4096 * (bbox[3] - float(item.lat)) / (bbox[3] - bbox[1]))
             feature = {
-                'geometry': f'POINT({point_x}, {point_y})',
+                'geometry': f'POINT({point_x} {point_y})',
                 'properties': {
                     'id': item.id,
                     'name': item.name or item.address,

--- a/webapp/repositories/location_repository.py
+++ b/webapp/repositories/location_repository.py
@@ -89,7 +89,12 @@ class LocationRepository(BaseRepository[Location]):
         if commit:
             self.session.commit()
 
-    def fetch_locations_summary_by_bounds(self, bbox: LngLatBbox, static: Optional[bool] = None, filter_duplicates: bool = True):
+    def fetch_locations_summary_by_bounds(
+        self,
+        bbox: LngLatBbox,
+        static: Optional[bool] = None,
+        filter_duplicates: bool = True,
+    ) -> list:
         additional_where = ''
         if static is not None:
             additional_where += f'AND evse.status {"=" if static is True else "!="} "STATIC"'


### PR DESCRIPTION
- use `mapbox-vector-tile` library instead of deprecated `vector-tile-base`
- add build dependencies for mapbox-vector-tile to dev docker image 
- split the prod docker image into a builder stage and a runtime stage, each with the necessary dependencies 
- adapt `TilesHandler` to use the new library
- a bit of code style / type hints cleanup

To test if the tile generation actually works, I imported some data into the locally running instance (with `flask stadtnavi import` command inside the container) and then tried to zoom in on the map at `localhost:5010` until a request for tile data is shown in the log output of flask. 