### PR TITLE
prevent ochp import error at empty results

### DIFF
--- a/webapp/services/import_services/ochp/ochp_api_client.py
+++ b/webapp/services/import_services/ochp/ochp_api_client.py
@@ -112,7 +112,11 @@ class OchpApiClient:
             ],
             remote_type_tags=[],
         )
+
         input_data: GetStatusEnvelopeInput = self.get_status_validator.validate(input_dict)
+
+        if input_data.Envelope.Body.GetStatusResponse is None:
+            return []
 
         return input_data.Envelope.Body.GetStatusResponse.evse
 

--- a/webapp/services/import_services/ochp/ochp_validators.py
+++ b/webapp/services/import_services/ochp/ochp_validators.py
@@ -33,6 +33,7 @@ from validataclass.validators import (
     EnumValidator,
     IntegerValidator,
     ListValidator,
+    Noneable,
     StringValidator,
     TimeFormat,
     TimeValidator,
@@ -270,7 +271,7 @@ class GetStatusEvseInput:
 
 @validataclass
 class GetStatusResponseInput:
-    GetStatusResponse: GetStatusEvseInput = DataclassValidator(GetStatusEvseInput)
+    GetStatusResponse: GetStatusEvseInput | None = Noneable(DataclassValidator(GetStatusEvseInput))
 
 
 @validataclass


### PR DESCRIPTION
Fixes an issue where there was a validation error when OCHP had no incremental realtime results.