### PR TITLE
Optimize Query

### DIFF
--- a/webapp/public_api/location_api/location_search_queries.py
+++ b/webapp/public_api/location_api/location_search_queries.py
@@ -38,7 +38,7 @@ from webapp.common.validation import SearchParamNotInList, SearchParamUnequal
 @search_query_dataclass
 class LocationSearchQuery(SortingMixin, OffsetPaginationMixin, BaseSearchQuery):
     # Set allowed sorting keys and default sorting key
-    sorted_by: str = AnyOfValidator(['name', 'created', 'modified']), Default('name')
+    sorted_by: str = AnyOfValidator(['id', 'name', 'created', 'modified']), Default('id')
 
     # Search filters
     name: str | None = SearchParamContains(), StringValidator()

--- a/webapp/repositories/location_repository.py
+++ b/webapp/repositories/location_repository.py
@@ -156,12 +156,12 @@ class LocationRepository(BaseRepository[Location]):
 
     def fetch_locations(self, search_query: BaseSearchQuery | None = None) -> PaginatedResult[Location]:
         options = [
-            selectinload(Location.images),
-            selectinload(Location.evses).selectinload(Evse.connectors),
-            selectinload(Location.evses).selectinload(Evse.images),
             joinedload(Location.operator).joinedload(Business.logo),
             joinedload(Location.suboperator).joinedload(Business.logo),
             joinedload(Location.owner).joinedload(Business.logo),
+            selectinload(Location.images),
+            selectinload(Location.evses).selectinload(Evse.connectors),
+            selectinload(Location.evses).selectinload(Evse.images),
             selectinload(Location.evses).selectinload(Evse.related_resources),
             selectinload(Location.regular_hours),
             selectinload(Location.exceptional_closings),


### PR DESCRIPTION
Turns out the order of the loading strategy is important, and that one needs to make the joinedloads first