### PR TITLE
eaaze adaption

### DIFF
--- a/config_dist_dev.yaml
+++ b/config_dist_dev.yaml
@@ -17,6 +17,8 @@ SOURCES:
     auto_fetch: false  # rather large dataset
   chargecloud_ludwigsburg:
     api_key: test-api-key
+  eaaze_pbw:
+    token: test-token
   chargecloud_pforzheim:
   chargecloud_stuttgart:
   heilbronn_neckarbogen:

--- a/tests/integration/services/import_services/ocpi/eaaze_pbw/eaaze_pbw_service_test.py
+++ b/tests/integration/services/import_services/ocpi/eaaze_pbw/eaaze_pbw_service_test.py
@@ -1,0 +1,64 @@
+"""
+Open ChargePoint DataBase OCPDB
+Copyright (C) 2026 binary butterfly GmbH
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from uuid import UUID
+
+from requests_mock import Mocker
+
+from webapp.common.sqlalchemy import SQLAlchemy
+from webapp.dependencies import dependencies
+from webapp.services.import_services.ocpi.eaaze_pbw import EaazePbwImportService
+
+SOURCE_URL = 'https://ocpi.eaaze.cloud/cpo/2.2.1/locations'
+
+EMPTY_OCPI_RESPONSE = {
+    'status_code': 1000,
+    'timestamp': '2026-01-01T00:00:00Z',
+    'data': [],
+}
+
+
+def test_eaaze_pbw_sends_x_request_id(db: SQLAlchemy, requests_mock: Mocker) -> None:
+    """Every request to eaaze_pbw must carry an X-Request-ID header containing a random uuid4."""
+    eaaze_pbw_service: EaazePbwImportService = dependencies.get_import_services().importer_by_uid['eaaze_pbw']
+
+    requests_mock.get(SOURCE_URL, status_code=200, json=EMPTY_OCPI_RESPONSE)
+
+    eaaze_pbw_service.download_and_save()
+
+    request_id = requests_mock.last_request.headers.get('X-Request-ID')
+    assert request_id is not None
+    # Must be a valid uuid4 (raises ValueError otherwise).
+    assert UUID(request_id).version == 4
+    # The token auth header must still be present.
+    assert requests_mock.last_request.headers['Authorization'].startswith('Token ')
+
+
+def test_eaaze_pbw_x_request_id_is_unique_per_request(db: SQLAlchemy, requests_mock: Mocker) -> None:
+    """The X-Request-ID must be regenerated for each request, not reused."""
+    eaaze_pbw_service: EaazePbwImportService = dependencies.get_import_services().importer_by_uid['eaaze_pbw']
+
+    requests_mock.get(SOURCE_URL, status_code=200, json=EMPTY_OCPI_RESPONSE)
+
+    eaaze_pbw_service.download_and_save()
+    eaaze_pbw_service.download_and_save()
+
+    request_ids = [request.headers.get('X-Request-ID') for request in requests_mock.request_history]
+    assert len(request_ids) == 2
+    assert all(request_id is not None for request_id in request_ids)
+    assert request_ids[0] != request_ids[1]

--- a/webapp/services/import_services/ocpi/eaaze_pbw/eaaze_pbw_service.py
+++ b/webapp/services/import_services/ocpi/eaaze_pbw/eaaze_pbw_service.py
@@ -127,6 +127,7 @@ class EaazePbwImportService(BaseImportService, ABC):
                 'Authorization': f'Token {self.config.get("token")}',
                 # OCPI requires a unique request identifier per request; eaaze_pbw enforces it.
                 'X-Request-ID': str(uuid4()),
+                'X-Correlation-ID': str(uuid4()),
             },
             params={'limit': 1000},
         )

--- a/webapp/services/import_services/ocpi/eaaze_pbw/eaaze_pbw_service.py
+++ b/webapp/services/import_services/ocpi/eaaze_pbw/eaaze_pbw_service.py
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import logging
 from abc import ABC
 from datetime import datetime, timezone
+from uuid import uuid4
 
 from validataclass.exceptions import ValidationError
 from validataclass.validators import DataclassValidator
@@ -46,7 +47,7 @@ class EaazePbwImportService(BaseImportService, ABC):
         uid='eaaze_pbw',
         name='PBW',
         public_url='https://www.pbw.de/?menu=unternehmen-parkenundladen',
-        source_url='https://ocpi.eaaze.cloud/ocpi/cpo/2.2.1/locations',
+        source_url='https://ocpi.eaaze.cloud/cpo/2.2.1/locations',
         has_realtime_data=True,
     )
 
@@ -122,7 +123,11 @@ class EaazePbwImportService(BaseImportService, ABC):
     def _download(self, url: str | None = None) -> OcpiInput:
         input_dict = self.json_request(
             url=url,
-            headers={'Authorization': f'Token {self.config.get("token")}'},
+            headers={
+                'Authorization': f'Token {self.config.get("token")}',
+                # OCPI requires a unique request identifier per request; eaaze_pbw enforces it.
+                'X-Request-ID': str(uuid4()),
+            },
             params={'limit': 1000},
         )
         return self.ocpi_validator.validate(input_dict)


### PR DESCRIPTION
eaaze changed their API path and requires the X-Request-ID header. resolves #220 